### PR TITLE
typo in comment for composer project settings 

### DIFF
--- a/Drupal8/sites/default/all.settings.php
+++ b/Drupal8/sites/default/all.settings.php
@@ -11,5 +11,5 @@
 // Defines where the sync folder of your configuration lives. In this case it's inside
 // the Drupal root, which is protected by amazee.io nginx configs, so it cannot be read
 // via the browser. If your Drupal root is inside a subfolder (like 'web') you can put the config
-// folder outside this subfolder for an advanced security measure: '../config.sync'.
+// folder outside this subfolder for an advanced security measure: '../config/sync'.
 $config_directories[CONFIG_SYNC_DIRECTORY] = 'sites/default/config/sync';


### PR DESCRIPTION
I assume a slash was meant there and not a dot
