### PR TITLE
Fix the ordering of arguments for explode()

### DIFF
--- a/Drupal8/sites/default/settings.php
+++ b/Drupal8/sites/default/settings.php
@@ -55,7 +55,7 @@ if (getenv('AMAZEEIO_SOLR_HOST') && getenv('AMAZEEIO_SOLR_PORT')) {
 
 ### amazee.io Varnish & Reverse proxy settings
 if (getenv('AMAZEEIO_VARNISH_HOSTS') && getenv('AMAZEEIO_VARNISH_SECRET')) {
-  $varnish_hosts = explode(getenv('AMAZEEIO_VARNISH_HOSTS'), ',');
+  $varnish_hosts = explode(',', getenv('AMAZEEIO_VARNISH_HOSTS'));
   array_walk($varnish_hosts, function(&$value, $key) { $value .= ':6082'; });
 
   $settings['reverse_proxy'] = TRUE;


### PR DESCRIPTION
Couldn't connect to varnish, it was reporting the connection as `,:6082`. This fixes the connection so it becomes `127.0.0.1:6082`