### PR TITLE
Switch to Curl and new drush-alias host

### DIFF
--- a/Drupal7/drush/aliases.drushrc.php
+++ b/Drupal7/drush/aliases.drushrc.php
@@ -2,6 +2,13 @@
 // Don't change anything here, it's magic!
 global $aliases_stub;
 if (empty($aliases_stub)) {
-  $aliases_stub = file_get_contents('https://raw.githubusercontent.com/amazeeio/drush-aliases/master/aliases.drushrc.php.stub?' . rand(0, 99999999999));
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_AUTOREFERER, TRUE);
+    curl_setopt($ch, CURLOPT_HEADER, 0);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    curl_setopt($ch, CURLOPT_URL, 'https://raw.githubusercontent.com/amazeeio/drush-aliases/master/aliases.drushrc.php.stub?' . rand(0, 99999999999));
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
+    $aliases_stub = curl_exec($ch);
+    curl_close($ch);
 }
 eval($aliases_stub);

--- a/Drupal7/drush/aliases.drushrc.php
+++ b/Drupal7/drush/aliases.drushrc.php
@@ -6,7 +6,7 @@ if (empty($aliases_stub)) {
     curl_setopt($ch, CURLOPT_AUTOREFERER, TRUE);
     curl_setopt($ch, CURLOPT_HEADER, 0);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-    curl_setopt($ch, CURLOPT_URL, 'https://raw.githubusercontent.com/amazeeio/drush-aliases/master/aliases.drushrc.php.stub?' . rand(0, 99999999999));
+    curl_setopt($ch, CURLOPT_URL, 'https://drush-alias.amazeeio.cloud/aliases.drushrc.php.stub');
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
     $aliases_stub = curl_exec($ch);
     curl_close($ch);

--- a/Drupal8/drush/aliases.drushrc.php
+++ b/Drupal8/drush/aliases.drushrc.php
@@ -2,6 +2,13 @@
 // Don't change anything here, it's magic!
 global $aliases_stub;
 if (empty($aliases_stub)) {
-  $aliases_stub = file_get_contents('https://raw.githubusercontent.com/amazeeio/drush-aliases/master/aliases.drushrc.php.stub?' . rand(0, 99999999999));
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_AUTOREFERER, TRUE);
+    curl_setopt($ch, CURLOPT_HEADER, 0);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    curl_setopt($ch, CURLOPT_URL, 'https://raw.githubusercontent.com/amazeeio/drush-aliases/master/aliases.drushrc.php.stub?' . rand(0, 99999999999));
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
+    $aliases_stub = curl_exec($ch);
+    curl_close($ch);
 }
 eval($aliases_stub);

--- a/Drupal8/drush/aliases.drushrc.php
+++ b/Drupal8/drush/aliases.drushrc.php
@@ -6,7 +6,7 @@ if (empty($aliases_stub)) {
     curl_setopt($ch, CURLOPT_AUTOREFERER, TRUE);
     curl_setopt($ch, CURLOPT_HEADER, 0);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-    curl_setopt($ch, CURLOPT_URL, 'https://raw.githubusercontent.com/amazeeio/drush-aliases/master/aliases.drushrc.php.stub?' . rand(0, 99999999999));
+    curl_setopt($ch, CURLOPT_URL, 'https://drush-alias.amazeeio.cloud/aliases.drushrc.php.stub');
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
     $aliases_stub = curl_exec($ch);
     curl_close($ch);


### PR DESCRIPTION
We're getting rid of file_get_contents and replace it with curl as this makes more sense and proved to be more stable.

On top of that we're also removing the by now really old inclusion of a script from github. We have a host which serves this file.