### PR TITLE
usage of `$AMAZEEIO_WEBROOT` is not encouraged

### DIFF
--- a/Drupal7/.amazeeio.yml
+++ b/Drupal7/.amazeeio.yml
@@ -3,12 +3,12 @@ sitegroup: replaceme
 deploy_tasks:
   development:
     after_deploy:
-      - cd $AMAZEEIO_WEBROOT && drush -y updb --cache-clear=0
-      - cd $AMAZEEIO_WEBROOT && drush -y cc all
+      - drush -y updb --cache-clear=0
+      - drush -y cc all
   production:
     after_deploy:
-      - cd $AMAZEEIO_WEBROOT && drush -y updb --cache-clear=0
-      - cd $AMAZEEIO_WEBROOT && drush -y cc all
+      - drush -y updb --cache-clear=0
+      - drush -y cc all
 
 shared:
   production:

--- a/Drupal8/.amazeeio.yml
+++ b/Drupal8/.amazeeio.yml
@@ -3,12 +3,12 @@ sitegroup: replaceme
 deploy_tasks:
   development:
     after_deploy:
-      - cd $AMAZEEIO_WEBROOT && drush -y updb --cache-clear=0
-      - cd $AMAZEEIO_WEBROOT && drush -y cr
+      - cd web && drush -y updb --cache-clear=0
+      - cd web && drush -y cr
   production:
     after_deploy:
-      - cd $AMAZEEIO_WEBROOT && drush -y updb --cache-clear=0
-      - cd $AMAZEEIO_WEBROOT && drush -y cr
+      - cd web && drush -y updb --cache-clear=0
+      - cd web && drush -y cr
 
 shared:
   production:


### PR DESCRIPTION
as it is an absolute path and during production deployments we are using release folders (see https://docs.amazee.io/automated_deployments.html) so we suggest to use the folder name directly