### PR TITLE
Do not disable CSS/JS aggregation on dev environments

### DIFF
--- a/Drupal8/sites/default/development.settings.php
+++ b/Drupal8/sites/default/development.settings.php
@@ -17,11 +17,9 @@ $config['google_analytics.settings']['account'] = 'UA-XXXXXXXX-YY';
 // Expiration of cached pages to 0
 $config['system.performance']['cache']['page']['max_age'] = 0;
 
-// Aggregate CSS files off
-$config['system.performance']['css']['preprocess'] = 0;
-
-// Aggregate JavaScript files off
-$config['system.performance']['js']['preprocess'] = 0;
+// Aggregate CSS/JS files to not confuse clients with browser cache issues.
+$config['system.performance']['css']['preprocess'] = 1;
+$config['system.performance']['js']['preprocess'] = 1;
 
 // Stage file proxy URL from production URL
 if(getenv('AMAZEEIO_PRODUCTION_URL')){

--- a/Drupal8/sites/default/example.local.settings.php
+++ b/Drupal8/sites/default/example.local.settings.php
@@ -10,3 +10,7 @@
 // Disable render caches, necessary for twig files to be reloaded on every page view
 $settings['cache']['bins']['render'] = 'cache.backend.null';
 $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
+
+// Disable CSS/JS aggregation.
+$config['system.performance']['css']['preprocess'] = 0;
+$config['system.performance']['js']['preprocess'] = 0;


### PR DESCRIPTION
We had CSS/JS aggregation disabled on Dev when we were developing HEKS. This regularly leaded to client reporting "new feature does not work" issues. We always replied with "clear browser cache" and this fixed the issue.

This happened too often, so we decided to enable CSS/JS aggregation on Dev and disable it locally in local.settings.php. Client testing improved much after that.

If you commit this, I'll do the same changes for d8-starter.